### PR TITLE
🔧 Fix - Update ESLint Rule Property Name

### DIFF
--- a/rules/base.js
+++ b/rules/base.js
@@ -27,7 +27,7 @@ module.exports = {
         'no-unused-vars': [
             1,
             {
-                ignoreSiblings: true,
+                ignoreRestSiblings: true,
                 argsIgnorePattern: 'res|next|^err',
             },
         ],


### PR DESCRIPTION
- Resolves issue that is breaking ESlint for projects using this config
- ESLint updated prop name and we had to update to match.